### PR TITLE
Improve bundle sizes

### DIFF
--- a/src/plugins/vis_type_xy/public/config/get_agg_id.ts
+++ b/src/plugins/vis_type_xy/public/config/get_agg_id.ts
@@ -17,5 +17,9 @@
  * under the License.
  */
 
-export { getConfig } from './get_config';
-export { getAggId } from './get_agg_id';
+/**
+ * Get agg id from accessor
+ *
+ * For now this is determined by the esaggs column name. Could be cleaned up in the future.
+ */
+export const getAggId = (accessor: string) => (accessor ?? '').split('-').pop() ?? '';

--- a/src/plugins/vis_type_xy/public/config/get_aspects.ts
+++ b/src/plugins/vis_type_xy/public/config/get_aspects.ts
@@ -25,6 +25,7 @@ import { DatatableColumn } from '../../../expressions/public';
 
 import { Aspect, Dimension, Aspects, Dimensions } from '../types';
 import { getFormatService } from '../services';
+import { getAggId } from './get_agg_id';
 
 export function getEmptyAspect(): Aspect {
   return {
@@ -78,13 +79,6 @@ function getAspectsFromDimension(
   const column = columns[dimensions.accessor];
   return column && getAspect(column, dimensions);
 }
-
-/**
- * Get agg id from accessor
- *
- * For now this is determined by the esaggs column name. Could be cleaned up in the future.
- */
-export const getAggId = (accessor: string) => (accessor ?? '').split('-').pop() ?? '';
 
 const getAspect = (
   { id: accessor, name: title }: DatatableColumn,

--- a/src/plugins/vis_type_xy/public/editor/collections.ts
+++ b/src/plugins/vis_type_xy/public/editor/collections.ts
@@ -24,32 +24,9 @@ import { AxisMode, ChartMode, InterpolationMode, ThresholdLineStyle, ScaleType }
 import { ChartType } from '../../common';
 import { LabelRotation } from '../../../charts/public';
 
-export const getPositions = () => [
-  {
-    text: i18n.translate('visTypeXy.legendPositions.topText', {
-      defaultMessage: 'Top',
-    }),
-    value: Position.Top,
-  },
-  {
-    text: i18n.translate('visTypeXy.legendPositions.leftText', {
-      defaultMessage: 'Left',
-    }),
-    value: Position.Left,
-  },
-  {
-    text: i18n.translate('visTypeXy.legendPositions.rightText', {
-      defaultMessage: 'Right',
-    }),
-    value: Position.Right,
-  },
-  {
-    text: i18n.translate('visTypeXy.legendPositions.bottomText', {
-      defaultMessage: 'Bottom',
-    }),
-    value: Position.Bottom,
-  },
-];
+export { getScaleTypes } from './scale_types';
+
+export { getPositions } from './positions';
 
 export const getChartTypes = () => [
   {
@@ -105,27 +82,6 @@ export const getInterpolationModes = () => [
       defaultMessage: 'Stepped',
     }),
     value: InterpolationMode.StepAfter,
-  },
-];
-
-export const getScaleTypes = () => [
-  {
-    text: i18n.translate('visTypeXy.scaleTypes.linearText', {
-      defaultMessage: 'Linear',
-    }),
-    value: ScaleType.Linear,
-  },
-  {
-    text: i18n.translate('visTypeXy.scaleTypes.logText', {
-      defaultMessage: 'Log',
-    }),
-    value: ScaleType.Log,
-  },
-  {
-    text: i18n.translate('visTypeXy.scaleTypes.squareRootText', {
-      defaultMessage: 'Square root',
-    }),
-    value: ScaleType.SquareRoot,
   },
 ];
 

--- a/src/plugins/vis_type_xy/public/editor/index.ts
+++ b/src/plugins/vis_type_xy/public/editor/index.ts
@@ -19,4 +19,3 @@
 
 export * from './common_config';
 export * from './collections';
-export * from './components';

--- a/src/plugins/vis_type_xy/public/editor/positions.ts
+++ b/src/plugins/vis_type_xy/public/editor/positions.ts
@@ -17,5 +17,32 @@
  * under the License.
  */
 
-export { getConfig } from './get_config';
-export { getAggId } from './get_agg_id';
+import { i18n } from '@kbn/i18n';
+import { Position } from '@elastic/charts';
+
+export const getPositions = () => [
+  {
+    text: i18n.translate('visTypeXy.legendPositions.topText', {
+      defaultMessage: 'Top',
+    }),
+    value: Position.Top,
+  },
+  {
+    text: i18n.translate('visTypeXy.legendPositions.leftText', {
+      defaultMessage: 'Left',
+    }),
+    value: Position.Left,
+  },
+  {
+    text: i18n.translate('visTypeXy.legendPositions.rightText', {
+      defaultMessage: 'Right',
+    }),
+    value: Position.Right,
+  },
+  {
+    text: i18n.translate('visTypeXy.legendPositions.bottomText', {
+      defaultMessage: 'Bottom',
+    }),
+    value: Position.Bottom,
+  },
+];

--- a/src/plugins/vis_type_xy/public/editor/scale_types.ts
+++ b/src/plugins/vis_type_xy/public/editor/scale_types.ts
@@ -17,5 +17,27 @@
  * under the License.
  */
 
-export { getConfig } from './get_config';
-export { getAggId } from './get_agg_id';
+import { i18n } from '@kbn/i18n';
+
+import { ScaleType } from '../types';
+
+export const getScaleTypes = () => [
+  {
+    text: i18n.translate('visTypeXy.scaleTypes.linearText', {
+      defaultMessage: 'Linear',
+    }),
+    value: ScaleType.Linear,
+  },
+  {
+    text: i18n.translate('visTypeXy.scaleTypes.logText', {
+      defaultMessage: 'Log',
+    }),
+    value: ScaleType.Log,
+  },
+  {
+    text: i18n.translate('visTypeXy.scaleTypes.squareRootText', {
+      defaultMessage: 'Square root',
+    }),
+    value: ScaleType.SquareRoot,
+  },
+];

--- a/src/plugins/vis_type_xy/public/index.ts
+++ b/src/plugins/vis_type_xy/public/index.ts
@@ -36,14 +36,12 @@ export {
   HistogramParams,
   DateHistogramParams,
 } from './types';
-export {
-  getPositions,
-  getScaleTypes,
-  TruncateLabelsOption,
-  ValidationVisOptionsProps,
-} from './editor';
+export type { ValidationVisOptionsProps } from './editor/components/common/validation_wrapper';
+export { TruncateLabelsOption } from './editor/components/common/truncate_labels';
+export { getPositions } from './editor/positions';
+export { getScaleTypes } from './editor/scale_types';
 export { xyVisTypes } from './vis_types';
-export { getAggId } from './config';
+export { getAggId } from './config/get_agg_id';
 
 // Export common types
 export * from '../common';

--- a/src/plugins/vis_type_xy/public/vis_renderer.tsx
+++ b/src/plugins/vis_type_xy/public/vis_renderer.tsx
@@ -26,7 +26,7 @@ import { ExpressionRenderDefinition } from '../../expressions/public';
 import { VisualizationContainer } from '../../visualizations/public';
 
 import { XyVisType } from '../common';
-import { SplitChartWarning } from './components';
+import { SplitChartWarning } from './components/split_chart_warning';
 import { VisComponentType } from './vis_component';
 import { RenderValue, visName } from './xy_vis_fn';
 


### PR DESCRIPTION
It's not much but this PR reduces the initial bundle size of `vis_type_xy` from 99kb to 67kb without many changes. The biggest part is the sync registration of vis types but I don't think it's worth changing something there