### PR TITLE
Fix scrolling bug when the legend has big height

### DIFF
--- a/src/plugins/vis_type_xy/public/_chart.scss
+++ b/src/plugins/vis_type_xy/public/_chart.scss
@@ -1,8 +1,4 @@
 .xyChart__container {
-  display: flex;
-  flex: 1 1 auto;
-  min-height: 0;
-  min-width: 0;
   position: absolute;
   top: 0;
   right: 0;

--- a/src/plugins/vis_type_xy/public/_chart.scss
+++ b/src/plugins/vis_type_xy/public/_chart.scss
@@ -1,5 +1,11 @@
 .xyChart__container {
-  width: 100%;
-  height: 100%;
-  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }


### PR DESCRIPTION
## Summary

It seems that there is a bug when the legend has many values and its height is greater than the chart. This PR fixes it.

<img width="1626" alt="Screenshot 2020-12-14 at 4 51 45 PM" src="https://user-images.githubusercontent.com/17003240/102095848-ae60e180-3e2c-11eb-8fc5-61f2a5fed11a.png">

I have tested it on Chrome, FF and Safari and it seems to work properly.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)