### PR TITLE
Testing state debounce with `lens.setPalette`

### DIFF
--- a/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
@@ -52,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.cleanStandardList();
     });
 
-    it('should sync colors on dashboard for legacy default palette', async function () {
+    it('should sync colors on dashboard for legacy default palette - problem test', async function () {
       await PageObjects.dashboard.navigateToApp();
       await elasticChart.setNewChartUiDebugFlag(true);
       await PageObjects.dashboard.clickCreateDashboardPrompt();
@@ -72,6 +72,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         palette: { mode: 'legacy', id: 'default' },
       });
       await PageObjects.lens.saveAndReturn();
+      // at this point the clearing of the `colorMapping` prop on the column is reverted to the default
+      // with the new color mapping switch enabled, this is driven by is the column has `colorMapping` defined.
       await PageObjects.header.waitUntilLoadingHasFinished();
 
       // create filtered xy chart
@@ -89,6 +91,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await filterBar.addFilter({ field: 'geo.src', operation: 'is not', value: 'CN' });
       await PageObjects.lens.saveAndReturn();
+      // Same thing happens here...
       await PageObjects.header.waitUntilLoadingHasFinished();
 
       // create datatable vis
@@ -102,6 +105,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await PageObjects.lens.setTermsNumberOfValues(5);
       await PageObjects.lens.setTableDynamicColoring('cell');
+
+      // Oddly this call to setPalette on the Table, works fine without the sleeps...
       await PageObjects.lens.setPalette('default', true);
       await PageObjects.lens.closeDimensionEditor();
       await PageObjects.lens.configureDimension({
@@ -118,6 +123,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.dashboard.waitForRenderComplete();
 
+      // This is just pulling all the colors from the 2 xy charts and the table and ensuring all keys are assigned the same color.
+      // i.e. "CN" -> "#ccc"
       const colorMappings1 = Object.entries(
         getColorMapping(await PageObjects.dashboard.getPanelChartDebugState(0))
       );

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1251,13 +1251,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async setPalette(paletteId: string, isLegacy: boolean) {
       await testSubjects.click('lns_colorEditing_trigger');
       // This action needs to be slowed WAY down, otherwise it will not correctly set the palette
-      await PageObjects.common.sleep(200);
+      // These three sleep are what finally fixed the issue for me.
+      // await PageObjects.common.sleep(200);
+
       await testSubjects.setEuiSwitch(
         'lns_colorMappingOrLegacyPalette_switch',
         isLegacy ? 'uncheck' : 'check'
       );
 
-      await PageObjects.common.sleep(200);
+      // await PageObjects.common.sleep(200);
 
       if (isLegacy) {
         await testSubjects.click('lns-palettePicker');
@@ -1266,9 +1268,14 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await testSubjects.click('kbnColoring_ColorMapping_PalettePicker');
         await testSubjects.click(`kbnColoring_ColorMapping_Palette-${paletteId}`);
       }
-      await PageObjects.common.sleep(200);
+
+      // If the debounced value is the root cause, they I would imagine a 1000 sleep here would fix it, but it does not
+      // maybe it needs to be after the call to `closePaletteEditor`?? idk
+      // await PageObjects.common.sleep(200);
 
       await this.closePaletteEditor();
+
+      // at this point without the sleeps, the value is set locally in the component so it looks correct
     },
 
     async closePaletteEditor() {


### PR DESCRIPTION
⚠️ Testing PR for comparing failed test runs.

This is the error you should see [here](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6803#01917fc0-5197-48bc-a8a5-06d06f262746/274-974).

```
└-: dashboard
--
  | └-> "before all" hook: beforeTestSuite.trigger in "dashboard"
  | └-: sync colors
  | └-> "before all" hook: beforeTestSuite.trigger for "should sync colors on dashboard for legacy default palette - problem test"
  | └-> "before all" hook for "should sync colors on dashboard for legacy default palette - problem test"
  | └-> should sync colors on dashboard for legacy default palette - problem test
  | └-> "before each" hook: global before each for "should sync colors on dashboard for legacy default palette - problem test"
  | └- ✖ fail: dashboard sync colors should sync colors on dashboard for legacy default palette - problem test
  | │       Error: Key "IN" was assigned multiple colors: ["#6092c0","#54b399"]
  | │       + expected - actual
  | │
  | │       -2
  | │       +1
  | │
  | │       at Assertion.assert (expect.js:100:11)
  | │       at Assertion.eql (expect.js:244:8)
  | │       at forEach (sync_colors.ts:156:29)
  | │       at Map.forEach (<anonymous>)
  | │       at Context.<anonymous> (sync_colors.ts:155:30)
  | │       at processTicksAndRejections (node:internal/process/task_queues:95:5)
  | │       at Object.apply (wrap_function.js:73:16)
  | │
  | │
  | └-> "after all" hook for "should be possible to disable color sync"
  | └-> "after all" hook: afterTestSuite.trigger for "should be possible to disable color sync"
  | └-> "after all" hook: afterTestSuite.trigger in "dashboard"
  |  
  | 0 passing (1.0m)
  | 1 failing
  |  
  | 1)    dashboard
  | sync colors
  | should sync colors on dashboard for legacy default palette - problem test:
  |  
  |  
  | Error: Key "IN" was assigned multiple colors: ["#6092c0","#54b399"]
  | + expected - actual
  |  
  | -2
  | +1
  |  
  | at Assertion.assert (expect.js:100:11)
  | at Assertion.eql (expect.js:244:8)
  | at forEach (sync_colors.ts:156:29)
  | at Map.forEach (<anonymous>)
  | at Context.<anonymous> (sync_colors.ts:155:30)
  | at processTicksAndRejections (node:internal/process/task_queues:95:5)
  | at Object.apply (wrap_function.js:73:16)
```